### PR TITLE
 Allow config nodes to be serialized separately

### DIFF
--- a/src/main/java/me/zeroeightsix/fiber/JanksonSettings.java
+++ b/src/main/java/me/zeroeightsix/fiber/JanksonSettings.java
@@ -45,7 +45,7 @@ public class JanksonSettings {
 			TreeItem item = node.lookup(key);
 			if (item != null) {
 				if (item instanceof Property) {
-					setPopertyValue((Property<?>) item, child);
+					setPropertyValue((Property<?>) item, child);
 				} else if (item instanceof Node && child instanceof JsonObject) {
 					deserialize((Node) item, (JsonObject) child);
 				} else {
@@ -58,7 +58,7 @@ public class JanksonSettings {
 		}
 	}
 
-	private <T> void setPopertyValue(Property<T> property, JsonElement child) {
+	private <T> void setPropertyValue(Property<T> property, JsonElement child) {
 		Class<T> type = property.getType();
 		property.setValue(marshall(type, child));
 	}
@@ -71,12 +71,14 @@ public class JanksonSettings {
 	private JsonObject serialize(Node node) {
 		JsonObject object = new JsonObject();
 
-		node.getItems().forEach(treeItem -> {
+		for (TreeItem treeItem : node.getItems()) {
 			String name = null;
 
 			if (treeItem instanceof Node) {
 				Node subNode = (Node) treeItem;
-				object.put((name = subNode.getName()), serialize(subNode));
+				if (!subNode.isSerializedSeparately()) {
+					object.put((name = subNode.getName()), serialize(subNode));
+				}
 			} else if (treeItem instanceof HasValue) {
 				object.put((name = treeItem.getName()), serialize((HasValue<?>) treeItem));
 			}
@@ -84,7 +86,7 @@ public class JanksonSettings {
 			if (name != null && treeItem instanceof Commentable) {
 				object.setComment(name, ((Commentable) treeItem).getComment());
 			}
-		});
+		}
 
 		return object;
 	}

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigNode.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigNode.java
@@ -9,9 +9,15 @@ public class ConfigNode extends ConfigLeaf implements Node, Commentable {
 
     @Nonnull
     private Set<TreeItem> items = new HashSet<>();
+    private boolean serializeSeparately;
+
+    public ConfigNode(@Nullable String name, @Nullable String comment, boolean serializeSeparately) {
+        super(name, comment);
+        this.serializeSeparately = serializeSeparately;
+    }
 
     public ConfigNode(@Nullable String name, @Nullable String comment) {
-        super(name, comment);
+        this(name, comment, false);
     }
 
     public ConfigNode() {
@@ -24,4 +30,8 @@ public class ConfigNode extends ConfigLeaf implements Node, Commentable {
         return items;
     }
 
+    @Override
+    public boolean isSerializedSeparately() {
+        return serializeSeparately;
+    }
 }

--- a/src/main/java/me/zeroeightsix/fiber/tree/Node.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/Node.java
@@ -12,6 +12,18 @@ public interface Node extends TreeItem {
     @Nonnull
     Set<TreeItem> getItems();
 
+    /**
+     * Returns {@code true} if this node should be serialized separately to its parent.
+     *
+     * <p> If a node is serialized separately, it should not appear in the serialized representation of
+     * its parent. This setting has no effect if this node is a root.
+     *
+     * @return {@code true} if this node should be serialized separately, and {@code false} otherwise
+     */
+    default boolean isSerializedSeparately() {
+        return false;
+    }
+
     @Nullable
     default TreeItem lookup(String name) {
         return getItems()
@@ -51,8 +63,28 @@ public interface Node extends TreeItem {
         return item;
     }
 
+    /**
+     * Forks this node, creating a subtree which parent is this node.
+     *
+     * @param name the name of the new {@code Node}
+     * @return the created node
+     * @throws FiberException if the new node cannot be added as a child to this node
+     */
     default Node fork(String name) throws FiberException {
-        return (Node) add(new ConfigNode(name, null));
+        return fork(name, false);
+    }
+
+    /**
+     * Forks this node, creating a subtree which parent is this node.
+     *
+     * @param name the name of the new {@code Node}
+     * @param serializeSeparately if {@code true}, the subtree will not appear in the
+     *                            serialized representation of this {@code Node}
+     * @return the created node
+     * @throws FiberException if the new node cannot be added as a child to this node
+     */
+    default Node fork(String name, boolean serializeSeparately) throws FiberException {
+        return (Node) add(new ConfigNode(name, null, serializeSeparately));
     }
 
 }

--- a/src/test/java/me/zeroeightsix/fiber/JanksonSettingsTest.java
+++ b/src/test/java/me/zeroeightsix/fiber/JanksonSettingsTest.java
@@ -1,0 +1,98 @@
+package me.zeroeightsix.fiber;
+
+import me.zeroeightsix.fiber.exception.FiberException;
+import me.zeroeightsix.fiber.tree.ConfigNode;
+import me.zeroeightsix.fiber.tree.ConfigValue;
+import me.zeroeightsix.fiber.tree.Node;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class JanksonSettingsTest {
+
+    @Test
+    @DisplayName("Node -> Node")
+    void nodeSerialization() throws IOException, FiberException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        JanksonSettings jk = new JanksonSettings();
+        Node nodeOne = new ConfigNode();
+        Node nodeTwo = new ConfigNode();
+
+        ConfigValue.builder(Integer.class)
+                .withName("A")
+                .withDefaultValue(10)
+                .withParent(nodeOne)
+                .build();
+
+        ConfigValue.builder(Integer.class)
+                .withName("A")
+                .withDefaultValue(20)
+                .withParent(nodeTwo)
+                .build();
+
+        jk.serialize(nodeOne, bos, false);
+        jk.deserialize(nodeTwo, new ByteArrayInputStream(bos.toByteArray()));
+        NodeOperationsTest.testNodeFor(nodeTwo, "A", Integer.class, 10);
+    }
+
+    @Test
+    @DisplayName("SubNode -> SubNode")
+    void nodeSerialization1() throws IOException, FiberException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        JanksonSettings jk = new JanksonSettings();
+        Node parentOne = new ConfigNode();
+        Node parentTwo = new ConfigNode();
+        Node childOne = parentOne.fork("child");
+        Node childTwo = parentTwo.fork("child");
+
+        ConfigValue.builder(Integer.class)
+                .withName("A")
+                .withDefaultValue(10)
+                .withParent(childOne)
+                .build();
+
+        ConfigValue.builder(Integer.class)
+                .withName("A")
+                .withDefaultValue(20)
+                .withParent(childTwo)
+                .build();
+
+        jk.serialize(parentOne, bos, false);
+        jk.deserialize(parentTwo, new ByteArrayInputStream(bos.toByteArray()));
+        NodeOperationsTest.testNodeFor(childTwo, "A", Integer.class, 10);
+    }
+
+    @Test
+    @DisplayName("Ignore SubNode")
+    void nodeSerialization2() throws IOException, FiberException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        JanksonSettings jk = new JanksonSettings();
+        Node parentOne = new ConfigNode();
+        Node parentTwo = new ConfigNode();
+        Node childOne = parentOne.fork("child", true);
+        Node childTwo = parentTwo.fork("child", true);
+
+        ConfigValue.builder(Integer.class)
+                .withName("A")
+                .withDefaultValue(10)
+                .withParent(childOne)
+                .build();
+
+        ConfigValue.builder(Integer.class)
+                .withName("A")
+                .withDefaultValue(20)
+                .withParent(childTwo)
+                .build();
+
+        jk.serialize(parentOne, bos, false);
+        jk.deserialize(parentTwo, new ByteArrayInputStream(bos.toByteArray()));
+        // the child data should not have been saved -> default value
+        NodeOperationsTest.testNodeFor(childTwo, "A", Integer.class, 20);
+    }
+
+}

--- a/src/test/java/me/zeroeightsix/fiber/NodeOperationsTest.java
+++ b/src/test/java/me/zeroeightsix/fiber/NodeOperationsTest.java
@@ -57,12 +57,12 @@ class NodeOperationsTest {
         testItemFor(Integer.class, 10, valueTwo);
     }
 
-    private <T> void testNodeFor(Node node, String name, Class<T> type, T value) {
+    static <T> void testNodeFor(Node node, String name, Class<T> type, T value) {
         TreeItem item = node.lookup(name);
         testItemFor(type, value, item);
     }
 
-    private <T> void testItemFor(Class<T> type, T value, TreeItem item) {
+    static <T> void testItemFor(Class<T> type, T value, TreeItem item) {
         assertTrue(item != null, "Setting exists");
         assertTrue(item instanceof Property<?>, "Setting is a property");
         Property<?> property = (Property<?>) item;


### PR DESCRIPTION
Sometimes when the configuration tree becomes too big, it is useful to serialize it as multiple files.
However, currently the whole tree is always serialized at once, making the above difficult.
This PR adds a new property to `Node` to prevent the default behaviour of serializing with the parent.