### PR TITLE
Add string constraints

### DIFF
--- a/src/main/java/me/zeroeightsix/fiber/annotation/AnnotatedSettings.java
+++ b/src/main/java/me/zeroeightsix/fiber/annotation/AnnotatedSettings.java
@@ -14,6 +14,7 @@ import me.zeroeightsix.fiber.tree.TreeItem;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -121,6 +122,9 @@ public class AnnotatedSettings {
     private static <T> void constrain(ConstraintsBuilder<T> constraints, Field field) {
         if (field.isAnnotationPresent(Setting.Constrain.Min.class)) constraints.minNumerical((T) Double.valueOf(field.getAnnotation(Setting.Constrain.Min.class).value()));
         if (field.isAnnotationPresent(Setting.Constrain.Max.class)) constraints.maxNumerical((T) Double.valueOf(field.getAnnotation(Setting.Constrain.Max.class).value()));
+        if (field.isAnnotationPresent(Setting.Constrain.MinStringLength.class)) constraints.minStringLength(field.getAnnotation(Setting.Constrain.MinStringLength.class).value());
+        if (field.isAnnotationPresent(Setting.Constrain.MaxStringLength.class)) constraints.maxStringLength(field.getAnnotation(Setting.Constrain.MaxStringLength.class).value());
+        if (field.isAnnotationPresent(Setting.Constrain.Regex.class)) constraints.regex(field.getAnnotation(Setting.Constrain.Regex.class).value());
         constraints.finish();
     }
 

--- a/src/main/java/me/zeroeightsix/fiber/annotation/Setting.java
+++ b/src/main/java/me/zeroeightsix/fiber/annotation/Setting.java
@@ -1,9 +1,13 @@
 package me.zeroeightsix.fiber.annotation;
 
+import javax.annotation.RegEx;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.FIELD)
 public @interface Setting {
 
     boolean constant() default false;
@@ -11,23 +15,44 @@ public @interface Setting {
     String comment() default "";
 
     boolean ignore() default false;
+
+    @Target(ElementType.FIELD)
     @Retention(RetentionPolicy.RUNTIME)
     @interface Node {
         String name() default "";
     }
 
-    @Retention(RetentionPolicy.RUNTIME)
+    @Target({})
     @interface Constrain {
 
+        @Target(ElementType.FIELD)
         @Retention(RetentionPolicy.RUNTIME)
         @interface Min {
             double value();
         }
 
+        @Target(ElementType.FIELD)
         @Retention(RetentionPolicy.RUNTIME)
         @interface Max {
             double value();
         }
 
+        @Target(ElementType.FIELD)
+        @Retention(RetentionPolicy.RUNTIME)
+        @interface MinStringLength {
+            int value();
+        }
+
+        @Target(ElementType.FIELD)
+        @Retention(RetentionPolicy.RUNTIME)
+        @interface MaxStringLength {
+            int value();
+        }
+
+        @Target(ElementType.FIELD)
+        @Retention(RetentionPolicy.RUNTIME)
+        @interface Regex {
+            @RegEx String value();
+        }
     }
 }

--- a/src/main/java/me/zeroeightsix/fiber/builder/constraint/AbstractConstraintsBuilder.java
+++ b/src/main/java/me/zeroeightsix/fiber/builder/constraint/AbstractConstraintsBuilder.java
@@ -3,67 +3,76 @@ package me.zeroeightsix.fiber.builder.constraint;
 import me.zeroeightsix.fiber.constraint.*;
 import me.zeroeightsix.fiber.exception.RuntimeFiberException;
 
+import javax.annotation.RegEx;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public abstract class AbstractConstraintsBuilder<T> {
+public abstract class AbstractConstraintsBuilder<T, B extends AbstractConstraintsBuilder<T, B>> {
 
-	final List<Constraint<? super T>> sourceConstraints;
-	protected final Class<T> type;
+    final List<Constraint<? super T>> sourceConstraints;
+    protected final Class<T> type;
 
-	final List<Constraint<? super T>> newConstraints = new ArrayList<>();
+    final List<Constraint<? super T>> newConstraints = new ArrayList<>();
 
-	AbstractConstraintsBuilder(List<Constraint<? super T>> sourceConstraints, Class<T> type) {
-		this.sourceConstraints = sourceConstraints;
-		this.type = type;
-	}
+    AbstractConstraintsBuilder(List<Constraint<? super T>> sourceConstraints, Class<T> type) {
+        this.sourceConstraints = sourceConstraints;
+        this.type = type;
+    }
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public void addNumericalLowerBound(T bound) throws RuntimeFiberException {
+	@SuppressWarnings({"unchecked", "rawtypes"})
+    public B minNumerical(T min) throws RuntimeFiberException {
 		checkNumerical();
-		checkNumerical(bound);
-		newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_LOWER_BOUND, (Number) bound));
-	}
+		checkNumerical(min);
+		newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_LOWER_BOUND, (Number) min));
+		return (B) this;
+    }
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public void addNumericalUpperBound(T bound) throws RuntimeFiberException {
+	@SuppressWarnings({"unchecked", "rawtypes"})
+    public B maxNumerical(T min) throws RuntimeFiberException {
 		checkNumerical();
-		checkNumerical(bound);
-		newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_UPPER_BOUND, (Number) bound));
-	}
+		checkNumerical(min);
+		newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_UPPER_BOUND, (Number) min));
+		return (B) this;
+    }
+
+    @SuppressWarnings("unchecked")
+	public B minStringLength(int min) {
+		checkCharSequence();
+		newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MINIMUM_LENGTH, min));
+		return (B) this;
+    }
 
 	@SuppressWarnings("unchecked")
-	public void addStringLengthLowerBound(int bound) throws RuntimeFiberException {
+    public B maxStringLength(int min) {
 		checkCharSequence();
-		newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MINIMUM_LENGTH, bound));
-	}
+		newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MAXIMUM_LENGTH, min));
+		return (B) this;
+    }
 
 	@SuppressWarnings("unchecked")
-	public void addStringLengthUpperBound(int bound) throws RuntimeFiberException {
+    public B regex(@RegEx String regexPattern) {
 		checkCharSequence();
-		newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MAXIMUM_LENGTH, bound));
-	}
-
-	@SuppressWarnings("unchecked")
-	public void addStringPattern(Pattern pattern) {
-		checkCharSequence();
-		newConstraints.add((Constraint<? super T>) new RegexConstraint(pattern));
-	}
+		newConstraints.add((Constraint<? super T>) new RegexConstraint(Pattern.compile(regexPattern)));
+		return (B) this;
+    }
 
 	private void checkNumerical() {
-		if (!Number.class.isAssignableFrom(this.type)) throw new UnsupportedOperationException("Can't apply numerical constraint to non-numerical setting");
-	}
+        if (!Number.class.isAssignableFrom(this.type))
+            throw new UnsupportedOperationException("Can't apply numerical constraint to non-numerical setting");
+    }
 
-	private void checkNumerical(T value) {
-		if (!Number.class.isAssignableFrom(value.getClass())) throw new IllegalArgumentException("'" + value + "' is not a number");
-	}
+    private void checkNumerical(T value) {
+        if (!Number.class.isAssignableFrom(value.getClass()))
+            throw new IllegalArgumentException("'" + value + "' is not a number");
+    }
 
-	private void checkCharSequence() {
-		if (!CharSequence.class.isAssignableFrom(this.type)) throw new UnsupportedOperationException("Can only apply regex pattern constraint to character sequences");
-	}
+    private void checkCharSequence() {
+        if (!CharSequence.class.isAssignableFrom(this.type))
+            throw new UnsupportedOperationException("Can only apply regex pattern constraint to character sequences");
+    }
 
-	void addConstraints() {
-		sourceConstraints.addAll(newConstraints);
-	}
+    void addConstraints() {
+        sourceConstraints.addAll(newConstraints);
+    }
 }

--- a/src/main/java/me/zeroeightsix/fiber/builder/constraint/AbstractConstraintsBuilder.java
+++ b/src/main/java/me/zeroeightsix/fiber/builder/constraint/AbstractConstraintsBuilder.java
@@ -1,12 +1,11 @@
 package me.zeroeightsix.fiber.builder.constraint;
 
+import me.zeroeightsix.fiber.constraint.*;
 import me.zeroeightsix.fiber.exception.RuntimeFiberException;
-import me.zeroeightsix.fiber.constraint.Constraint;
-import me.zeroeightsix.fiber.constraint.Constraints;
-import me.zeroeightsix.fiber.constraint.NumberConstraint;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public abstract class AbstractConstraintsBuilder<T> {
 
@@ -22,22 +21,49 @@ public abstract class AbstractConstraintsBuilder<T> {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void addNumericalLowerBound(T bound) throws RuntimeFiberException {
+		checkNumerical();
 		checkNumerical(bound);
 		newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_LOWER_BOUND, (Number) bound));
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void addNumericalUpperBound(T bound) throws RuntimeFiberException {
+		checkNumerical();
 		checkNumerical(bound);
 		newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_UPPER_BOUND, (Number) bound));
 	}
 
+	@SuppressWarnings("unchecked")
+	public void addStringLengthLowerBound(int bound) throws RuntimeFiberException {
+		checkCharSequence();
+		newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MINIMUM_LENGTH, bound));
+	}
+
+	@SuppressWarnings("unchecked")
+	public void addStringLengthUpperBound(int bound) throws RuntimeFiberException {
+		checkCharSequence();
+		newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MAXIMUM_LENGTH, bound));
+	}
+
+	@SuppressWarnings("unchecked")
+	public void addStringPattern(Pattern pattern) {
+		checkCharSequence();
+		newConstraints.add((Constraint<? super T>) new RegexConstraint(pattern));
+	}
+
+	private void checkNumerical() {
+		if (!Number.class.isAssignableFrom(this.type)) throw new UnsupportedOperationException("Can't apply numerical constraint to non-numerical setting");
+	}
+
 	private void checkNumerical(T value) {
-		if (!Number.class.isAssignableFrom(value.getClass())) throw new IllegalStateException("Can't apply numerical constraint to non-numerical setting");
+		if (!Number.class.isAssignableFrom(value.getClass())) throw new IllegalArgumentException("'" + value + "' is not a number");
+	}
+
+	private void checkCharSequence() {
+		if (!CharSequence.class.isAssignableFrom(this.type)) throw new UnsupportedOperationException("Can only apply regex pattern constraint to character sequences");
 	}
 
 	void addConstraints() {
 		sourceConstraints.addAll(newConstraints);
 	}
-
 }

--- a/src/main/java/me/zeroeightsix/fiber/builder/constraint/AbstractConstraintsBuilder.java
+++ b/src/main/java/me/zeroeightsix/fiber/builder/constraint/AbstractConstraintsBuilder.java
@@ -20,44 +20,44 @@ public abstract class AbstractConstraintsBuilder<T, B extends AbstractConstraint
         this.type = type;
     }
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public B minNumerical(T min) throws RuntimeFiberException {
-		checkNumerical();
-		checkNumerical(min);
-		newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_LOWER_BOUND, (Number) min));
-		return (B) this;
+        checkNumerical();
+        checkNumerical(min);
+        newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_LOWER_BOUND, (Number) min));
+        return (B) this;
     }
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public B maxNumerical(T min) throws RuntimeFiberException {
-		checkNumerical();
-		checkNumerical(min);
-		newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_UPPER_BOUND, (Number) min));
-		return (B) this;
+        checkNumerical();
+        checkNumerical(min);
+        newConstraints.add(new NumberConstraint(Constraints.NUMERICAL_UPPER_BOUND, (Number) min));
+        return (B) this;
     }
 
     @SuppressWarnings("unchecked")
-	public B minStringLength(int min) {
-		checkCharSequence();
-		newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MINIMUM_LENGTH, min));
-		return (B) this;
+    public B minStringLength(int min) {
+        checkCharSequence();
+        newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MINIMUM_LENGTH, min));
+        return (B) this;
     }
 
-	@SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked")
     public B maxStringLength(int min) {
-		checkCharSequence();
-		newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MAXIMUM_LENGTH, min));
-		return (B) this;
+        checkCharSequence();
+        newConstraints.add((Constraint<? super T>) new StringLengthConstraint(Constraints.STRING_MAXIMUM_LENGTH, min));
+        return (B) this;
     }
 
-	@SuppressWarnings("unchecked")
+    @SuppressWarnings("unchecked")
     public B regex(@RegEx String regexPattern) {
-		checkCharSequence();
-		newConstraints.add((Constraint<? super T>) new RegexConstraint(Pattern.compile(regexPattern)));
-		return (B) this;
+        checkCharSequence();
+        newConstraints.add((Constraint<? super T>) new RegexConstraint(Pattern.compile(regexPattern)));
+        return (B) this;
     }
 
-	private void checkNumerical() {
+    private void checkNumerical() {
         if (!Number.class.isAssignableFrom(this.type))
             throw new UnsupportedOperationException("Can't apply numerical constraint to non-numerical setting");
     }

--- a/src/main/java/me/zeroeightsix/fiber/builder/constraint/CompositeConstraintBuilder.java
+++ b/src/main/java/me/zeroeightsix/fiber/builder/constraint/CompositeConstraintBuilder.java
@@ -5,9 +5,10 @@ import me.zeroeightsix.fiber.constraint.Constraint;
 import me.zeroeightsix.fiber.constraint.Constraints;
 import me.zeroeightsix.fiber.constraint.ValuedConstraint;
 
+import javax.annotation.RegEx;
 import java.util.List;
 
-public final class CompositeConstraintBuilder<T> extends AbstractConstraintsBuilder<T> {
+public final class CompositeConstraintBuilder<T> extends AbstractConstraintsBuilder<T, CompositeConstraintBuilder<T>> {
 
 	private final ConstraintsBuilder<T> source;
 	private final CompositeType compositeType;
@@ -16,16 +17,6 @@ public final class CompositeConstraintBuilder<T> extends AbstractConstraintsBuil
 		super(sourceConstraints, type);
 		this.source = source;
 		this.compositeType = compositeType;
-	}
-
-	public CompositeConstraintBuilder<T> minNumerical(T min) {
-		addNumericalLowerBound(min);
-		return this;
-	}
-
-	public CompositeConstraintBuilder<T> maxNumerical(T min) {
-		addNumericalUpperBound(min);
-		return this;
 	}
 
 	public ConstraintsBuilder<T> finishComposite() {

--- a/src/main/java/me/zeroeightsix/fiber/builder/constraint/ConstraintsBuilder.java
+++ b/src/main/java/me/zeroeightsix/fiber/builder/constraint/ConstraintsBuilder.java
@@ -9,7 +9,7 @@ import javax.annotation.RegEx;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public final class ConstraintsBuilder<T> extends AbstractConstraintsBuilder<T> {
+public final class ConstraintsBuilder<T> extends AbstractConstraintsBuilder<T, ConstraintsBuilder<T>> {
 
 	final ConfigValueBuilder<T> source;
 
@@ -20,31 +20,6 @@ public final class ConstraintsBuilder<T> extends AbstractConstraintsBuilder<T> {
 
 	public CompositeConstraintBuilder<T> composite(CompositeType type) {
 		return new CompositeConstraintBuilder<>(type, sourceConstraints, this.type, this);
-	}
-
-	public ConstraintsBuilder<T> minNumerical(T min) throws RuntimeFiberException {
-		addNumericalLowerBound(min);
-		return this;
-	}
-
-	public ConstraintsBuilder<T> maxNumerical(T min) throws RuntimeFiberException {
-		addNumericalUpperBound(min);
-		return this;
-	}
-
-	public ConstraintsBuilder<T> minStringLength(int min) {
-		addStringLengthLowerBound(min);
-		return this;
-	}
-
-	public ConstraintsBuilder<T> maxStringLength(int min) {
-		addStringLengthUpperBound(min);
-		return this;
-	}
-
-	public ConstraintsBuilder<T> regex(@RegEx String regexPattern) {
-		addStringPattern(Pattern.compile(regexPattern));
-		return this;
 	}
 
 	public ConfigValueBuilder<T> finish() {

--- a/src/main/java/me/zeroeightsix/fiber/builder/constraint/ConstraintsBuilder.java
+++ b/src/main/java/me/zeroeightsix/fiber/builder/constraint/ConstraintsBuilder.java
@@ -1,11 +1,13 @@
 package me.zeroeightsix.fiber.builder.constraint;
 
 import me.zeroeightsix.fiber.builder.ConfigValueBuilder;
-import me.zeroeightsix.fiber.exception.RuntimeFiberException;
 import me.zeroeightsix.fiber.constraint.CompositeType;
 import me.zeroeightsix.fiber.constraint.Constraint;
+import me.zeroeightsix.fiber.exception.RuntimeFiberException;
 
+import javax.annotation.RegEx;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public final class ConstraintsBuilder<T> extends AbstractConstraintsBuilder<T> {
 
@@ -30,9 +32,23 @@ public final class ConstraintsBuilder<T> extends AbstractConstraintsBuilder<T> {
 		return this;
 	}
 
+	public ConstraintsBuilder<T> minStringLength(int min) {
+		addStringLengthLowerBound(min);
+		return this;
+	}
+
+	public ConstraintsBuilder<T> maxStringLength(int min) {
+		addStringLengthUpperBound(min);
+		return this;
+	}
+
+	public ConstraintsBuilder<T> regex(@RegEx String regexPattern) {
+		addStringPattern(Pattern.compile(regexPattern));
+		return this;
+	}
+
 	public ConfigValueBuilder<T> finish() {
 		super.addConstraints();
 		return source;
 	}
-
 }

--- a/src/main/java/me/zeroeightsix/fiber/constraint/Constraints.java
+++ b/src/main/java/me/zeroeightsix/fiber/constraint/Constraints.java
@@ -7,8 +7,7 @@ public enum Constraints {
 	NUMERICAL_UPPER_BOUND(true, identifier("max")),
 	STRING_MINIMUM_LENGTH(true, identifier("min_length")),
 	STRING_MAXIMUM_LENGTH(true, identifier("max_length")),
-	STRING_STARTING_WITH(false, identifier("starts_with")),
-	STRING_ENDING_WITH(false, identifier("ends_with")),
+	STRING_MATCHING(false, identifier("regex")),
 	FINAL(false, identifier("final")),
 	COMPOSITE(false, identifier("composite"));
 

--- a/src/main/java/me/zeroeightsix/fiber/constraint/RegexConstraint.java
+++ b/src/main/java/me/zeroeightsix/fiber/constraint/RegexConstraint.java
@@ -1,0 +1,14 @@
+package me.zeroeightsix.fiber.constraint;
+
+import java.util.regex.Pattern;
+
+public class RegexConstraint extends ValuedConstraint<Pattern, CharSequence> {
+    public RegexConstraint(Pattern value) {
+        super(Constraints.STRING_MATCHING, value);
+    }
+
+    @Override
+    public boolean test(CharSequence value) {
+        return this.getValue().matcher(value).matches();
+    }
+}

--- a/src/main/java/me/zeroeightsix/fiber/constraint/StringLengthConstraint.java
+++ b/src/main/java/me/zeroeightsix/fiber/constraint/StringLengthConstraint.java
@@ -1,0 +1,23 @@
+package me.zeroeightsix.fiber.constraint;
+
+public class StringLengthConstraint extends ValuedConstraint<Integer, CharSequence> {
+
+    public StringLengthConstraint(Constraints type, Integer value) {
+        super(type, value);
+        if (type != Constraints.STRING_MINIMUM_LENGTH && type != Constraints.STRING_MAXIMUM_LENGTH) {
+            throw new IllegalArgumentException(type + " is not a string length constraint");
+        }
+    }
+
+    @Override
+    public boolean test(CharSequence value) {
+        switch (getType()) {
+            case STRING_MINIMUM_LENGTH:
+                return value.length() >= this.getValue();
+            case STRING_MAXIMUM_LENGTH:
+                return value.length() <= this.getValue();
+            default:
+                throw new IllegalStateException("A StringLengthConstraint must be of type STRING_MINIMUM_LENGTH or STRING_MAXIMUM_LENGTH");
+        }
+    }
+}

--- a/src/test/java/me/zeroeightsix/fiber/annotation/AnnotatedSettingsTest.java
+++ b/src/test/java/me/zeroeightsix/fiber/annotation/AnnotatedSettingsTest.java
@@ -103,6 +103,20 @@ class AnnotatedSettingsTest {
     }
 
     @Test
+    @DisplayName("String constraints")
+    void testStringConstraints() throws FiberException {
+        StringConstraintsPojo pojo = new StringConstraintsPojo();
+        AnnotatedSettings.applyToNode(node, pojo);
+        @SuppressWarnings("unchecked")
+        Property<String> value = (Property<String>) node.lookup("a");
+        assertNotNull(value, "Setting exists");
+        assertFalse(value.setValue("BAD STRING::"));
+        assertTrue(value.setValue("good:string"));
+        assertFalse(value.setValue("b:s"), "Too short");
+        assertFalse(value.setValue("bad_string:because_it_is_way_too_long"), "Too long");
+    }
+
+    @Test
     @DisplayName("Only annotated fields")
     void testOnlyAnnotatedFields() throws FiberException {
         OnlyAnnotatedFieldsPojo pojo = new OnlyAnnotatedFieldsPojo();
@@ -203,6 +217,13 @@ class AnnotatedSettingsTest {
         @Setting.Constrain.Min(0)
         @Setting.Constrain.Max(10)
         private int a = 5;
+    }
+
+    private static class StringConstraintsPojo {
+        @Setting.Constrain.MinStringLength(5)
+        @Setting.Constrain.MaxStringLength(20)
+        @Setting.Constrain.Regex("[a-z0-9_.-]{2,}:[a-z0-9_./-]+?")
+        private String a = "fabric:test";
     }
 
     @Settings(onlyAnnotated = true)


### PR DESCRIPTION
This PR implements the length bound constraints that had been previously planned, as well as a regular expression pattern constraint replacing the less versatile prefix and suffix constraints.
I also took the opportunity to add `Target` information to every `Setting` annotation.