### PR TITLE
Add config queries

### DIFF
--- a/src/main/java/me/zeroeightsix/fiber/exception/FiberException.java
+++ b/src/main/java/me/zeroeightsix/fiber/exception/FiberException.java
@@ -5,11 +5,11 @@ package me.zeroeightsix.fiber.exception;
  */
 public class FiberException extends Exception {
 
-    public FiberException(String s) {
-        super(s);
+    public FiberException(String message) {
+        super(message);
     }
 
-    public FiberException(String s, Throwable throwable) {
-        super(s, throwable);
+    public FiberException(String message, Throwable cause) {
+        super(message, cause);
     }
 }

--- a/src/main/java/me/zeroeightsix/fiber/exception/FiberQueryException.java
+++ b/src/main/java/me/zeroeightsix/fiber/exception/FiberQueryException.java
@@ -1,0 +1,105 @@
+package me.zeroeightsix.fiber.exception;
+
+import me.zeroeightsix.fiber.tree.ConfigQuery;
+import me.zeroeightsix.fiber.tree.Node;
+import me.zeroeightsix.fiber.tree.NodeLike;
+import me.zeroeightsix.fiber.tree.TreeItem;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * Signals that an exception occurred while running a {@link ConfigQuery}.
+ *
+ * <p> This class is the general class of exceptions produced by failed
+ * config tree queries.
+ */
+public class FiberQueryException extends FiberException {
+    private final NodeLike invalidTree;
+
+    public FiberQueryException(String message, NodeLike invalidTree) {
+        super(message + (invalidTree instanceof Node && ((Node) invalidTree).getName() != null
+                ? " (in subtree " + ((Node) invalidTree).getName() + ")" : ""));
+        this.invalidTree = invalidTree;
+    }
+
+    public FiberQueryException(String message, Throwable cause, NodeLike invalidTree) {
+        super(message, cause);
+        this.invalidTree = invalidTree;
+    }
+
+    /**
+     * Returns the last valid ancestor before which the error occurred.
+     *
+     * <p> The invalid tree may be the tree directly passed to the query,
+     * or it may be a descendant node.
+     *
+     * @return the parent of the erroring node.
+     */
+    public NodeLike getErrorParent() {
+        return invalidTree;
+    }
+
+    /**
+     * Checked exception thrown when a query fails to find a child
+     * with a given name from an ancestor node.
+     */
+    public static class MissingChild extends FiberQueryException {
+        private final String missingNodeName;
+
+        public MissingChild(String name, NodeLike invalidTree) {
+            super("Missing child " + name, invalidTree);
+            this.missingNodeName = name;
+        }
+
+        /**
+         * Returns the name of the missing child.
+         *
+         * @return the name of the missing child
+         */
+        @Nonnull
+        public String getMissingChildName() {
+            return missingNodeName;
+        }
+    }
+
+    /**
+     * Checked exception thrown when a query finds a node of
+     * a different type than expected.
+     */
+    public static class WrongType extends FiberQueryException {
+        private final TreeItem invalidItem;
+        private final Class<?> expectedNodeType;
+        @Nullable
+        private final Class<?> expectedValueType;
+
+        public WrongType(NodeLike invalidTree, TreeItem invalidItem, Class<?> expectedNodeType, @Nullable Class<?> expectedValueType) {
+            super("Expected node of type " + expectedNodeType.getSimpleName()
+                    + (expectedValueType == null ? "" : "<" + expectedValueType.getSimpleName() + ">")
+                    + ", got " + invalidItem, invalidTree);
+            this.invalidItem = invalidItem;
+            this.expectedNodeType = expectedNodeType;
+            this.expectedValueType = expectedValueType;
+        }
+
+        public TreeItem getInvalidNode() {
+            return invalidItem;
+        }
+
+        public Class<?> getExpectedNodeType() {
+            return expectedNodeType;
+        }
+
+        /**
+         * Returns the type of property values expected by the query.
+         *
+         * <p> If the query expected an ancestor node to be found, this method returns {@code null}.
+         *
+         * @return the expected value type, or {@code null} if the query did not expect a property
+         */
+        @Nullable
+        public Class<?> getExpectedValueType() {
+            return expectedValueType;
+        }
+    }
+}

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigQuery.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigQuery.java
@@ -1,0 +1,70 @@
+package me.zeroeightsix.fiber.tree;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A query that can be run against any config tree to try and get a node.
+ *
+ * <p> A {@code ConfigQuery} follows a path in the tree, represented by a list of strings.
+ * It can notably be used to retrieve nodes from various config trees with a similar structure.
+ *
+ * @param <T> the type of queried tree nodes
+ */
+public final class ConfigQuery<T extends TreeItem> {
+    public static ConfigQuery<Node> node(String first, String... more) {
+        return new ConfigQuery<>(Node.class, null, first, more);
+    }
+
+    public static <V> ConfigQuery<ConfigValue<V>> property(Class<V> valueType, String first, String... more) {
+        return new ConfigQuery<>(ConfigValue.class, valueType, first, more);
+    }
+
+    private final List<String> path;
+    private final Class<? super T> nodeType;
+    @Nullable private final Class<?> valueType;
+
+    private ConfigQuery(Class<? super T> nodeType, @Nullable Class<?> valueType, String first, String[] path) {
+        this.nodeType = nodeType;
+        this.valueType = valueType;
+        this.path = new ArrayList<>();
+        this.path.add(first);
+        this.path.addAll(Arrays.asList(path));
+    }
+
+    public Optional<T> run(NodeLike tree) {
+        NodeLike subTree = tree;
+        List<String> path = this.path;
+        int len = path.size();
+        for (int i = 0; i < len; i++) {
+            TreeItem node = subTree.lookup(path.get(i));
+            if (i == len - 1) {
+                if (isValidResult(node)) {
+                    @SuppressWarnings("unchecked") Optional<T> result = (Optional<T>) Optional.of(node);
+                    return result;
+                }
+            } else if (node instanceof NodeLike) {
+                subTree = (NodeLike) node;
+            } else {
+                break;
+            }
+        }
+        return Optional.empty();
+    }
+
+    private boolean isValidResult(TreeItem node) {
+        return nodeType.isInstance(node) && (valueType == null || valueType.isAssignableFrom(((ConfigValue<?>)node).getType()));
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder().append(nodeType.getSimpleName());
+        if (valueType != null) {
+            sb.append('<').append(valueType.getSimpleName()).append('>');
+        }
+        return sb.append("@'").append(String.join(".", path)).append('\'').toString();
+    }
+}

--- a/src/main/java/me/zeroeightsix/fiber/tree/ConfigValue.java
+++ b/src/main/java/me/zeroeightsix/fiber/tree/ConfigValue.java
@@ -133,4 +133,9 @@ public class ConfigValue<T> extends ConfigLeaf implements Property<T> {
         return constraints;
     }
 
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + '<' + getType().getSimpleName() + ">[name=" + getName() + ", comment=" + getComment() + "]";
+    }
+
 }

--- a/src/test/java/me/zeroeightsix/fiber/tree/ConfigQueryTest.java
+++ b/src/test/java/me/zeroeightsix/fiber/tree/ConfigQueryTest.java
@@ -1,0 +1,44 @@
+package me.zeroeightsix.fiber.tree;
+
+import me.zeroeightsix.fiber.builder.ConfigNodeBuilder;
+import me.zeroeightsix.fiber.exception.FiberQueryException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConfigQueryTest {
+
+    @Test
+    void run() throws FiberQueryException {
+        AtomicReference<ConfigValue<Integer>> a = new AtomicReference<>();
+        ConfigNode tree = new ConfigNodeBuilder()
+                .fork("child")
+                .fork("stuff")
+                .beginValue("A", 10)
+                .finishValue(a::set)
+                .finishNode()
+                .finishNode()
+                .build();
+        ConfigQuery<?> query1 = ConfigQuery.property(Integer.class , "child", "stuff", "A");
+        assertEquals(a.get(), query1.run(tree));
+        assertTrue(query1.search(tree).isPresent());
+
+        ConfigQuery<?> query2 = ConfigQuery.property(Integer.class, "child", "more");
+        assertFalse(query2.search(tree).isPresent());
+        assertThrows(FiberQueryException.MissingChild.class, () -> query2.run(tree));
+
+        ConfigQuery<?> query3 = ConfigQuery.subtree("child", "stuff", "A");
+        assertThrows(FiberQueryException.WrongType.class, () -> query3.run(tree));
+        assertFalse(query3.search(tree).isPresent());
+
+        ConfigQuery<?> query4 = ConfigQuery.property(String.class, "child", "stuff", "A");
+        assertThrows(FiberQueryException.WrongType.class, () -> query4.run(tree));
+        assertFalse(query4.search(tree).isPresent());
+
+        ConfigQuery<?> query5 = ConfigQuery.property(Integer.class, "child", "stuff", "A", "more");
+        assertThrows(FiberQueryException.WrongType.class, () -> query5.run(tree));
+        assertFalse(query5.search(tree).isPresent());
+    }
+}


### PR DESCRIPTION
## The problem

Sometimes, you have a bunch of configs that use the same schema. Maybe you use the same config structure for every block in your mod, or you have two representations of the same config (eg. local and remote). Whatever the reason, the fact is that it is currently quite a chore to quickly access the same property in various trees. 

```java
NodeLike cfg = ...;
// Optimistic handling, the tree must conform exactly
@SuppressWarnings("unchecked") Property<String> prop = 
        (Property<String>) ((Node) ((Node)cfg.lookup("cat1")).lookup("cat2")).lookup("prop");
```
```java
NodeLike cfg = ...;
// Realistic handling
TreeItem i1 = cfg.lookup("cat1");
if (i1 instanceof Node) {
    TreeItem i2 = ((Node)i1).lookup("cat2");
    if (i2 instanceof Node) {
        TreeItem i3 = ((Node)i2).lookup("prop");
        if (i3 instanceof Property && String.class == ((Property<?>)i3).getType) {
            @SuppressWarnings("unchecked") Property<String> prop1 = (Property<String>) i3;
            // ...
        }
    }
}
```

## The solution
A simple `ConfigQuery` class that handles the work for us :
```java
ConfigQuery<ConfigValue<String>> propQuery = ConfigQuery.property(
        String.class,
        "cat1",
        "cat2",
        "prop"
);

NodeLike cfg = ...;
Optional<Property<String>> prop = propQuery.search(cfg);
// or
try {
    Property<String> prop1 = propQuery.run(cfg);
} catch (FiberQueryException e) {
    LOGGER.error("Malformed config", e);
}
```

```